### PR TITLE
One hot encode

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ new_source.to_source(new_source_name='New Filtered Source')
 - [rasgo_levenshtein](https://docs.rasgoml.com/rasgo-docs/pyrasgo/user-defined-transforms-udts/column-transforms/rasgo_levenshtein)
 - [rasgo_todate](https://docs.rasgoml.com/rasgo-docs/pyrasgo/user-defined-transforms-udts/column-transforms/rasgo_todate)
 - [rasgo_impute](https://docs.rasgoml.com/rasgo-docs/pyrasgo/user-defined-transforms-udts/column-transforms/rasgo_impute)
+- [rasgo_one_hot_encode](https://docs.rasgoml.com/rasgo-docs/pyrasgo/user-defined-transforms-udts/column-transforms/rasgo_one_hot_encode)
 
 ## Table Transforms
 - [rasgo_pivot](https://docs.rasgoml.com/rasgo-docs/pyrasgo/user-defined-transforms-udts/table-transforms/rasgo_pivot)

--- a/column_transforms/rasgo_impute/rasgo_impute.yaml
+++ b/column_transforms/rasgo_impute/rasgo_impute.yaml
@@ -1,5 +1,5 @@
 name: rasgo_impute
-transform_type: row
+transform_type: column
 source_code: rasgo_impute.sql
 description:  Impute missing values in column/columns with the mean, median, mode, or a value
 arguments:
@@ -20,5 +20,5 @@ example_code: |
           'COVID_DEATHS': 2.45,       # Impute with the float 2.45
           'IS_2021': False            # Impute with the bool False
       },
-    flag_missing_vals=True
+      flag_missing_vals=True
     ).preview()

--- a/column_transforms/rasgo_one_hot_encode/rasgo_one_hot_encode.sql
+++ b/column_transforms/rasgo_one_hot_encode/rasgo_one_hot_encode.sql
@@ -1,0 +1,34 @@
+{#
+Jinja Macro to generate a query that would get all 
+the columns in a table by fqtn
+#}
+{%- macro get_source_col_names(source_table_fqtn) -%}
+    {%- set database, schema, table = '', '', '' -%}
+    {%- set database, schema, table = source_table_fqtn.split('.') -%}
+    SELECT COLUMN_NAME FROM {{ database }}.information_schema.columns
+    WHERE TABLE_CATALOG = '{{ database }}'
+    AND   TABLE_SCHEMA = '{{ schema }}'
+    AND   TABLE_NAME = '{{ table }}'
+{%- endmacro -%}
+
+{# Marcro to make queries for one hot encode columns #}
+{%- macro gen_one_hot_encode_queries() -%}
+    {%- set distinct_col_vals =  run_query("SELECT DISTINCT " +  column + " FROM " + source_table)[column].to_list() -%}
+    {%- for val in  distinct_col_vals %}
+    CASE WHEN {{ column }} = {{ "'" + val +  "'" if val is string else val}} THEN 1 ELSE 0 END as {{ '"' }}{{ column }}_{{ val }}{{ '"' }},
+    {%- endfor %}
+    CASE WHEN {{ column }} IS NULL THEN 1 ELSE 0 END as {{ column }}_IS_NULL
+{%- endmacro -%}
+
+{# Get all Columns in Source Table #}
+{%- set col_names_source_df = run_query(get_source_col_names(source_table_fqtn=source_table)) -%}
+{%- set source_col_names = col_names_source_df['COLUMN_NAME'].to_list() -%}
+
+SELECT
+{%- for col in source_col_names -%}
+    {%- if col != column %}
+    {{ col }},
+    {%- endif -%}
+{%- endfor -%}
+    {{ gen_one_hot_encode_queries() }}
+FROM {{source_table}}

--- a/column_transforms/rasgo_one_hot_encode/rasgo_one_hot_encode.yaml
+++ b/column_transforms/rasgo_one_hot_encode/rasgo_one_hot_encode.yaml
@@ -3,7 +3,7 @@ transform_type: column
 source_code: rasgo_one_hot_encode.sql
 description:  One hot encode a column and drop it from the dataset. Create a null value flag for the column too.
 arguments:
-  imputations:
+  column:
     type: column
     description: Column name to one hot encode
 example_code: |

--- a/column_transforms/rasgo_one_hot_encode/rasgo_one_hot_encode.yaml
+++ b/column_transforms/rasgo_one_hot_encode/rasgo_one_hot_encode.yaml
@@ -1,0 +1,13 @@
+name: rasgo_one_hot_encode
+transform_type: column
+source_code: rasgo_one_hot_encode.sql
+description:  One hot encode a column and drop it from the dataset. Create a null value flag for the column too.
+arguments:
+  imputations:
+    type: column
+    description: Column name to one hot encode
+example_code: |
+    source.transform(
+      transform_id=transform.id,
+      column="MONTH"
+    ).preview()

--- a/docs/column_transforms/rasgo_impute.md
+++ b/docs/column_transforms/rasgo_impute.md
@@ -25,7 +25,7 @@ source.transform(
       'COVID_DEATHS': 2.45,       # Impute with the float 2.45
       'IS_2021': False            # Impute with the bool False
   },
-flag_missing_vals=True
+  flag_missing_vals=True
 ).preview()
 
 ```

--- a/docs/column_transforms/rasgo_one_hot_encode.md
+++ b/docs/column_transforms/rasgo_one_hot_encode.md
@@ -1,0 +1,27 @@
+
+
+# rasgo_one_hot_encode
+
+One hot encode a column and drop it from the dataset. Create a null value flag for the column too.
+
+## Parameters
+
+|  Argument   |  Type  |          Description          |
+| ----------- | ------ | ----------------------------- |
+| imputations | column | Column name to one hot encode |
+
+
+## Example
+
+```python
+source.transform(
+  transform_id=transform.id,
+  column="MONTH"
+).preview()
+
+```
+
+## Source Code
+
+{% embed url="https://github.com/rasgointelligence/RasgoUDTs/blob/main/column_transforms/rasgo_one_hot_encode/rasgo_one_hot_encode.sql" %}
+


### PR DESCRIPTION
One hot encode UDT.

Works like below

```python
print(source.transform(
    transform_id=transform.id,
    column="MONTH"
).preview_sql())
```
Outputs

```sql
SELECT
    DATE,
    COVID_DEATHS,
    YEAR,
    COVID_CUMULATIVE_CASES,
    FIPS,
    COVID_NEW_CASES,
    CASE WHEN MONTH = 4 THEN 1 ELSE 0 END as "MONTH_4",
    CASE WHEN MONTH = 9 THEN 1 ELSE 0 END as "MONTH_9",
    CASE WHEN MONTH = 8 THEN 1 ELSE 0 END as "MONTH_8",
    CASE WHEN MONTH = 6 THEN 1 ELSE 0 END as "MONTH_6",
    CASE WHEN MONTH = 3 THEN 1 ELSE 0 END as "MONTH_3",
    CASE WHEN MONTH = 2 THEN 1 ELSE 0 END as "MONTH_2",
    CASE WHEN MONTH = 5 THEN 1 ELSE 0 END as "MONTH_5",
    CASE WHEN MONTH = 7 THEN 1 ELSE 0 END as "MONTH_7",
    CASE WHEN MONTH = 1 THEN 1 ELSE 0 END as "MONTH_1",
    CASE WHEN MONTH = 11 THEN 1 ELSE 0 END as "MONTH_11",
    CASE WHEN MONTH = 10 THEN 1 ELSE 0 END as "MONTH_10",
    CASE WHEN MONTH = 12 THEN 1 ELSE 0 END as "MONTH_12",
    CASE WHEN MONTH IS NULL THEN 1 ELSE 0 END as MONTH_IS_NULL
FROM RASGOCOMMUNITY.PUBLIC.COVID_MONTHLY_FEATURES
```