### PR TITLE
Find and replace udt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+.DS_Store
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/column_transforms/rasgo_find_and_replace/rasgo_find_and_replace.sql
+++ b/column_transforms/rasgo_find_and_replace/rasgo_find_and_replace.sql
@@ -1,0 +1,38 @@
+{#
+Jinja Macro to generate a query that would get all 
+the columns in a table by fqtn
+#}
+{%- macro get_source_col_names(source_table_fqtn) -%}
+    {%- set database, schema, table = '', '', '' -%}
+    {%- set database, schema, table = source_table_fqtn.split('.') -%}
+    SELECT COLUMN_NAME FROM {{ database }}.information_schema.columns
+    WHERE TABLE_CATALOG = '{{ database }}'
+    AND   TABLE_SCHEMA = '{{ schema }}'
+    AND   TABLE_NAME = '{{ table }}'
+{%- endmacro -%}
+
+{%- macro quote_if_string(val) -%}
+    {{ "'" + val + "'" if val is string else val }}
+{%- endmacro -%}
+
+{%- set col_names_source_df = run_query(get_source_col_names(source_table_fqtn=source_table)) -%}
+{%- set source_col_names = col_names_source_df['COLUMN_NAME'].to_list() -%}
+
+{# Preset vars used below #}
+{%- set find_val, replace_val = [None, None] -%}
+
+SELECT
+{%- for col in source_col_names %}
+    {%- if col in replace_dict %}
+    CASE
+        {% for replacement_pair in replace_dict[col] -%}
+            {%- set find_val, replace_val = replacement_pair -%}
+        WHEN {{ col }} = {{ quote_if_string(find_val) }} THEN {{ quote_if_string(replace_val) }}
+        {% endfor -%}
+        ELSE {{ col }}
+    END as {{ col }}{{ ',' if not loop.last else '' }}
+    {%- else %}
+    {{ col }}{{ ',' if not loop.last else '' }}
+    {%- endif -%}
+{% endfor %}
+FROM {{ source_table }}

--- a/column_transforms/rasgo_find_and_replace/rasgo_find_and_replace.yaml
+++ b/column_transforms/rasgo_find_and_replace/rasgo_find_and_replace.yaml
@@ -1,0 +1,16 @@
+name: rasgo_find_and_replace
+transform_type: column
+source_code: rasgo_find_and_replace.sql
+description:  Replace certain values in a column/s on equality and add a specified reaplacement
+arguments:
+  replace_dict:
+    type: replace_dict
+    description: Dictionary with keys as the column to make replacements for. Values are a nested List. Each inner list the first element would be the value to search, and the second the value to replace.
+example_code: |
+    source.transform(
+        transform_name=transform_name,
+        replace_dict={
+            "MONTH": [[4, 44], [2, 22]],   # Replace value 4 with 44 in MONTH column. Also replace 2 with 22.
+            "FIPS": [['45001', '455001']]  # Replace value '45001' with '455001' in FIPS column.
+        }
+    ).preview()

--- a/column_transforms/rasgo_find_and_replace/rasgo_find_and_replace.yaml
+++ b/column_transforms/rasgo_find_and_replace/rasgo_find_and_replace.yaml
@@ -5,12 +5,12 @@ description:  Replace certain values in a column/s on equality and add a specifi
 arguments:
   replace_dict:
     type: replace_dict
-    description: Dictionary with keys as the column to make replacements for. Values are a nested List. Each inner list the first element would be the value to search, and the second the value to replace.
+    description: Dictionary with keys as the column to make replacements for. Values are a nested List. In each inner list the first element would be the value to search (None means NULL), and the second the value the one to replace that with.
 example_code: |
     source.transform(
-        transform_name=transform_name,
+        transform_name=rasgo_find_and_replace,
         replace_dict={
-            "MONTH": [[4, 44], [2, 22]],   # Replace value 4 with 44 in MONTH column. Also replace 2 with 22.
+            "MONTH": [[2, 22], [None, 44]],   # Also replace 2 with 22 in MONTH column. Also replace value NULL with 44 
             "FIPS": [['45001', '455001']]  # Replace value '45001' with '455001' in FIPS column.
         }
     ).preview()

--- a/docs/column_transforms/rasgo_find_and_replace.md
+++ b/docs/column_transforms/rasgo_find_and_replace.md
@@ -6,18 +6,18 @@ Replace certain values in a column/s on equality and add a specified reaplacemen
 
 ## Parameters
 
-|   Argument   |     Type     |                                                                                         Description                                                                                         |
-| ------------ | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| replace_dict | replace_dict | Dictionary with keys as the column to make replacements for. Values are a nested List. Each inner list the first element would be the value to search, and the second the value to replace. |
+|   Argument   |     Type     |                                                                                                            Description                                                                                                             |
+| ------------ | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| replace_dict | replace_dict | Dictionary with keys as the column to make replacements for. Values are a nested List. In each inner list the first element would be the value to search (None means NULL), and the second the value the one to replace that with. |
 
 
 ## Example
 
 ```python
 source.transform(
-    transform_name=transform_name,
+    transform_name=rasgo_find_and_replace,
     replace_dict={
-        "MONTH": [[4, 44], [2, 22]],   # Replace value 4 with 44 in MONTH column. Also replace 2 with 22.
+        "MONTH": [[2, 22], [None, 44]],   # Also replace 2 with 22 in MONTH column. Also replace value NULL with 44 
         "FIPS": [['45001', '455001']]  # Replace value '45001' with '455001' in FIPS column.
     }
 ).preview()


### PR DESCRIPTION
Made find and replace UDT. Works by supplying a column/s and a nested list of find + replace vals, and will do the replacements.

For example

```python
source.transform(
    transform_name=transform_name,
    replace_dict={
        "MONTH": [[4, 44], [2, 22]],   # Replace value 4 with 44 in MONTH column. Also replace 2 with 22.
        "FIPS": [['45001', '455001']]  # Replace value '45001' with '455001' in FIPS column.
    }
).preview()
```

will produce

```sql
SELECT
    YEAR,
    COVID_DEATHS,
    DATE,
    COVID_NEW_CASES,
    CASE
        WHEN FIPS = '45001' THEN '455001'
        ELSE FIPS
    END as FIPS,
    CASE
        WHEN MONTH = 4 THEN 44
        WHEN MONTH = 2 THEN 22
        ELSE MONTH
    END as MONTH,
    COVID_CUMULATIVE_CASES
FROM RASGOCOMMUNITY.PUBLIC.COVID_MONTHLY_FEATURES
```