### PR TITLE
date_diff udt made

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+.DS_Store
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ t1.to_source(new_source_name='New Filtered Source')
 - [rasgo_movingavg](https://docs.rasgoml.com/rasgo-docs/pyrasgo/user-defined-transforms-udts/column-transforms/rasgo_movingavg)
 - [rasgo_math](https://docs.rasgoml.com/rasgo-docs/pyrasgo/user-defined-transforms-udts/column-transforms/rasgo_math)
 - [rasgo_train_test_split](https://docs.rasgoml.com/rasgo-docs/pyrasgo/user-defined-transforms-udts/column-transforms/rasgo_train_test_split)
+- [rasgo_datediff](https://docs.rasgoml.com/rasgo-docs/pyrasgo/user-defined-transforms-udts/column-transforms/rasgo_datediff)
 
 ## Table Transforms
 - [rasgo_pivot](https://docs.rasgoml.com/rasgo-docs/pyrasgo/user-defined-transforms-udts/table-transforms/rasgo_pivot)

--- a/column_transforms/rasgo_datediff/rasgo_datediff.sql
+++ b/column_transforms/rasgo_datediff/rasgo_datediff.sql
@@ -1,0 +1,3 @@
+SELECT *,
+DATEDIFF({{ date_part }}, {{ date_col_1 }}, {{ date_col_2 }}) as {{ date_col_2 }}_{{ date_col_1 }}_{{ date_part }}_datediff
+FROM {{ source_table }}

--- a/column_transforms/rasgo_datediff/rasgo_datediff.sql
+++ b/column_transforms/rasgo_datediff/rasgo_datediff.sql
@@ -1,3 +1,3 @@
 SELECT *,
-DATEDIFF({{ date_part }}, {{ date_val_1 }}, {{ date_val_2 }}) as cleanse_name(date_val_2 + '_' + date_val_1  + '_' + date_part + '_datediff')
+DATEDIFF({{ date_part }}, {{ date_val_1 }}, {{ date_val_2 }}) as {{ cleanse_name(date_val_2 + '_' + date_val_1  + '_' + date_part + '_datediff') }}
 FROM {{ source_table }}

--- a/column_transforms/rasgo_datediff/rasgo_datediff.sql
+++ b/column_transforms/rasgo_datediff/rasgo_datediff.sql
@@ -1,3 +1,3 @@
 SELECT *,
-DATEDIFF({{ date_part }}, {{ date_col_1 }}, {{ date_col_2 }}) as {{ date_col_2 }}_{{ date_col_1 }}_{{ date_part }}_datediff
+DATEDIFF({{ date_part }}, {{ date_val_1 }}, {{ date_val_2 }}) as cleanse_name(date_val_2 + '_' + date_val_1  + '_' + date_part + '_datediff')
 FROM {{ source_table }}

--- a/column_transforms/rasgo_datediff/rasgo_datediff.yaml
+++ b/column_transforms/rasgo_datediff/rasgo_datediff.yaml
@@ -7,21 +7,26 @@ arguments:
     type: string
     description: |
        Must be one of the values listed in [Supported Date and Time Parts](https://docs.snowflake.com/en/sql-reference/functions-date-time.html#label-supported-date-time-parts)
-  date_col_1:
-    type: column
-    description: Date column to subtract from `date_col_2`. Must be a date column.
-  date_col_2:
-    type: column
-    description: Date column to be subtracted by `date_col_1`. Must be a date column.
+  date_val_1:
+    type: string
+    description: Date column to subtract from `date_val_2`. Can be a date column, date, time, or timestamp.
+  date_val_2:
+    type: string
+    description: Date column to be subtracted by `date_val_1`. Can be a date column, date, time, or timestamp.
 example_code: |
     source = rasgo.read.source_data(source.id)
     
-    # Create DateDiff col for 'START_DATE' - 'END_DATE'
+    # Create DateDiff col for year diff 'START_DATE' - 'END_DATE'
     t1 = source.transform(
       transform_name='rasgo_datediff',
       date_part='year',
-      date_col_1='END_DATE',
+      date_val_1='END_DATE',
       date_col_2='START_DATE'
     )
     
-    t1.preview()
+    # Subtract 'END_DATE' from start of 2022 new year
+    t2 = t1.transform(
+      transform_name='rasgo_datediff',
+      date_val_1='END_DATE',
+      date_val_2="'2022-01-01'"
+    ).preview()

--- a/column_transforms/rasgo_datediff/rasgo_datediff.yaml
+++ b/column_transforms/rasgo_datediff/rasgo_datediff.yaml
@@ -1,0 +1,27 @@
+name: rasgo_datediff
+transform_type: column
+source_code: rasgo_datediff.sql
+description: Calculates the difference between two date, time, or timestamp expressions based on the date or time part requested. The function returns the result of subtracting the second argument from the third argument.
+arguments:
+  date_part:
+    type: string
+    description: |
+       Must be one of the values listed in [Supported Date and Time Parts](https://docs.snowflake.com/en/sql-reference/functions-date-time.html#label-supported-date-time-parts)
+  date_col_1:
+    type: column
+    description: Date column to subtract from `date_col_2`. Must be a date column.
+  date_col_2:
+    type: column
+    description: Date column to be subtracted by `date_col_1`. Must be a date column.
+example_code: |
+    source = rasgo.read.source_data(source.id)
+    
+    # Create DateDiff col for 'START_DATE' - 'END_DATE'
+    t1 = source.transform(
+      transform_name='rasgo_datediff',
+      date_part='year',
+      date_col_1='END_DATE',
+      date_col_2='START_DATE'
+    )
+    
+    t1.preview()

--- a/column_transforms/rasgo_datediff/rasgo_datediff.yaml
+++ b/column_transforms/rasgo_datediff/rasgo_datediff.yaml
@@ -17,15 +17,15 @@ example_code: |
     source = rasgo.read.source_data(source.id)
     
     # Create DateDiff col for year diff 'START_DATE' - 'END_DATE'
-    t1 = source.transform(
+    source.transform(
       transform_name='rasgo_datediff',
       date_part='year',
       date_val_1='END_DATE',
       date_col_2='START_DATE'
-    )
+    ).preview()
     
     # Subtract 'END_DATE' from start of 2022 new year
-    t2 = t1.transform(
+    source.transform(
       transform_name='rasgo_datediff',
       date_val_1='END_DATE',
       date_val_2="'2022-01-01'"

--- a/column_transforms/rasgo_todate/rasgo_todate.yaml
+++ b/column_transforms/rasgo_todate/rasgo_todate.yaml
@@ -14,8 +14,8 @@ example_code: |
     
     t1 = source.transform(
       transform_name='rasgo_todate',
-      format_expression = 'YYYY-MM-DD',
-      date_columns = ['dt_str', ]
+      format_expression='YYYY-MM-DD',
+      date_columns=['dt_str']
     )
     
     t1.preview()

--- a/docs/column_transforms/rasgo_datediff.md
+++ b/docs/column_transforms/rasgo_datediff.md
@@ -9,8 +9,8 @@ Calculates the difference between two date, time, or timestamp expressions based
 |  Argument  |  Type  |                                                                                Description                                                                                 |
 | ---------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | date_part  | string | Must be one of the values listed in [Supported Date and Time Parts](https://docs.snowflake.com/en/sql-reference/functions-date-time.html#label-supported-date-time-parts)  |
-| date_col_1 | column | Date column to subtract from `date_col_2`. Must be a date column.                                                                                                          |
-| date_col_2 | column | Date column to be subtracted by `date_col_1`. Must be a date column.                                                                                                       |
+| date_val_1 | string | Date column to subtract from `date_val_2`. Can be a date column, date, time, or timestamp.                                                                                 |
+| date_val_2 | string | Date column to be subtracted by `date_val_1`. Can be a date column, date, time, or timestamp.                                                                              |
 
 
 ## Example
@@ -18,15 +18,20 @@ Calculates the difference between two date, time, or timestamp expressions based
 ```python
 source = rasgo.read.source_data(source.id)
 
-# Create DateDiff col for 'START_DATE' - 'END_DATE'
+# Create DateDiff col for year diff 'START_DATE' - 'END_DATE'
 t1 = source.transform(
   transform_name='rasgo_datediff',
   date_part='year',
-  date_col_1='END_DATE',
+  date_val_1='END_DATE',
   date_col_2='START_DATE'
 )
 
-t1.preview()
+# Subtract 'END_DATE' from start of 2022 new year
+t2 = t1.transform(
+  transform_name='rasgo_datediff',
+  date_val_1='END_DATE',
+  date_val_2="'2022-01-01'"
+).preview()
 ```
 
 ## Source Code

--- a/docs/column_transforms/rasgo_datediff.md
+++ b/docs/column_transforms/rasgo_datediff.md
@@ -1,0 +1,35 @@
+
+
+# rasgo_datediff
+
+Calculates the difference between two date, time, or timestamp expressions based on the date or time part requested. The function returns the result of subtracting the second argument from the third argument.
+
+## Parameters
+
+|  Argument  |  Type  |                                                                                Description                                                                                 |
+| ---------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| date_part  | string | Must be one of the values listed in [Supported Date and Time Parts](https://docs.snowflake.com/en/sql-reference/functions-date-time.html#label-supported-date-time-parts)  |
+| date_col_1 | column | Date column to subtract from `date_col_2`. Must be a date column.                                                                                                          |
+| date_col_2 | column | Date column to be subtracted by `date_col_1`. Must be a date column.                                                                                                       |
+
+
+## Example
+
+```python
+source = rasgo.read.source_data(source.id)
+
+# Create DateDiff col for 'START_DATE' - 'END_DATE'
+t1 = source.transform(
+  transform_name='rasgo_datediff',
+  date_part='year',
+  date_col_1='END_DATE',
+  date_col_2='START_DATE'
+)
+
+t1.preview()
+```
+
+## Source Code
+
+{% embed url="https://github.com/rasgointelligence/RasgoUDTs/blob/main/column_transforms/rasgo_datediff/rasgo_datediff.sql" %}
+

--- a/docs/column_transforms/rasgo_datediff.md
+++ b/docs/column_transforms/rasgo_datediff.md
@@ -19,15 +19,15 @@ Calculates the difference between two date, time, or timestamp expressions based
 source = rasgo.read.source_data(source.id)
 
 # Create DateDiff col for year diff 'START_DATE' - 'END_DATE'
-t1 = source.transform(
+source.transform(
   transform_name='rasgo_datediff',
   date_part='year',
   date_val_1='END_DATE',
   date_col_2='START_DATE'
-)
+).preview()
 
 # Subtract 'END_DATE' from start of 2022 new year
-t2 = t1.transform(
+source.transform(
   transform_name='rasgo_datediff',
   date_val_1='END_DATE',
   date_val_2="'2022-01-01'"

--- a/docs/column_transforms/rasgo_todate.md
+++ b/docs/column_transforms/rasgo_todate.md
@@ -19,8 +19,8 @@ source = rasgo.read.source_data(source.id)
 
 t1 = source.transform(
   transform_name='rasgo_todate',
-  format_expression = 'YYYY-MM-DD',
-  date_columns = ['dt_str', ]
+  format_expression='YYYY-MM-DD',
+  date_columns=['dt_str']
 )
 
 t1.preview()

--- a/docs/table_transforms/rasgo_datespine.md
+++ b/docs/table_transforms/rasgo_datespine.md
@@ -33,10 +33,10 @@ rasgo.read.source_data(w_source.id, limit=5)
 
 t1 = w_source.transform(
   transform_name='rasgo_datespine',
-  date_col = 'event_dt',
-  start_timestamp = '2017-01-01 12:00:00',
-  start_timestamp = '2020-01-01 12:00:00',
-  interval_type = 'month'
+  date_col='event_dt',
+  start_timestamp='2017-01-01 12:00:00',
+  start_timestamp='2020-01-01 12:00:00',
+  interval_type='month'
 )
 
 t1.preview()

--- a/row_transforms/rasgo_filter/rasgo_filter.sql
+++ b/row_transforms/rasgo_filter/rasgo_filter.sql
@@ -1,9 +1,4 @@
 SELECT * FROM {{source_table}}
-{%- macro quote_if_string(var) -%}
-    {%- set quote = "'" if var is string else '' -%}
-    {{ quote }}{{ var }}{{ quote }}
-{%- endmacro -%}
-
 {%- for filter_statement in filter_statements %}
 {{ 'WHERE' if loop.first else 'AND' }} {{ filter_statement }}
 {%- endfor -%}

--- a/table_transforms/rasgo_datespine/rasgo_datespine.yaml
+++ b/table_transforms/rasgo_datespine/rasgo_datespine.yaml
@@ -32,10 +32,10 @@ example_code: |
 
     t1 = w_source.transform(
       transform_name='rasgo_datespine',
-      date_col = 'event_dt',
-      start_timestamp = '2017-01-01 12:00:00',
-      start_timestamp = '2020-01-01 12:00:00',
-      interval_type = 'month'
+      date_col='event_dt',
+      start_timestamp='2017-01-01 12:00:00',
+      start_timestamp='2020-01-01 12:00:00',
+      interval_type='month'
     )
 
     t1.preview()


### PR DESCRIPTION
Date diff UDT. Subtracts `date_val_1` from `date_val_2` by the specified `date_part`.

NOTE: The [cleanse_name PR](https://github.com/rasgointelligence/RasgoAPI/pull/177) needs to be merged first for this to work

Example
```python
source.transform(
     transform_name=transform_name,
    date_part='minute',
    date_val_1='END_DATE',
    date_val_2="'2022-01-01'"
    ).preview_sql()
```

Outputs
```sql
SELECT *,
DATEDIFF(minute, END_DATE, '2022-01-01') as '2022-01-01'_END_DATE_minute_datediff
FROM RASGOCOMMUNITY.PUBLIC.COVID_MONTHLY_FEATURES
```
