### PR TITLE
add train/test split UDT

### DIFF
--- a/column_transforms/rasgo_train_test_split/rasgo_train_test_split.sql
+++ b/column_transforms/rasgo_train_test_split/rasgo_train_test_split.sql
@@ -1,0 +1,4 @@
+SELECT *,
+CASE WHEN ROW_NUMBER() OVER (ORDER BY {{order_by | join(", ")}} ) < (COUNT(1) OVER () * {{train_percent}}) THEN 'Train' ELSE 'Test' END AS TT_SPLIT
+
+FROM {{ source_table }}

--- a/column_transforms/rasgo_train_test_split/rasgo_train_test_split.yaml
+++ b/column_transforms/rasgo_train_test_split/rasgo_train_test_split.yaml
@@ -1,0 +1,21 @@
+name: rasgo_train_test_split
+transform_type: column
+source_code: rasgo_train_test_split.sql
+description: Label rows as part of the train or test set based off of percentage split you want to apply to the data
+arguments:
+  order_by:
+    type: column_list
+    description: names of column(s) you want order by for the train/test split
+  train_percent:
+    type: value
+    description: Percent of the data you want in the train set, expressed as a decimal (i.e. .8). The rest of the rows will be included in the test set.
+example_code: |
+    source = rasgo.read.source_data(source.id)
+    
+    t1 = source.transform(
+      transform_name='rasgo_train_test_split',
+      order_by = ['DATE'],
+      train_percent = 0.8
+    )
+    
+    t1.preview()

--- a/docs/column_transforms/rasgo_train_test_split.md
+++ b/docs/column_transforms/rasgo_train_test_split.md
@@ -1,0 +1,32 @@
+
+
+# rasgo_train_test_split
+
+Label rows as part of the train or test set based off of percentage split you want to apply to the data
+
+## Parameters
+
+|   Argument    |    Type     |                                                               Description                                                               |
+| ------------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| order_by      | column_list | names of column(s) you want order by for the train/test split                                                                           |
+| train_percent | value       | Percent of the data you want in the train set, expressed as a decimal (i.e. .8). The rest of the rows will be included in the test set. |
+
+
+## Example
+
+```python
+source = rasgo.read.source_data(source.id)
+
+t1 = source.transform(
+  transform_name='rasgo_train_test_split',
+  order_by = ['DATE'],
+  train_percent = 0.8
+)
+
+t1.preview()
+```
+
+## Source Code
+
+{% embed url="https://github.com/rasgointelligence/RasgoUDTs/blob/main/column_transforms/rasgo_train_test_split/rasgo_train_test_split.sql" %}
+


### PR DESCRIPTION
shippable like this but should add a RAND option for when theres no date to order by (and make the order by optional so it can be excluded in that scenario)