### PR TITLE
Rasgo join

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ new_source.to_source(new_source_name='New Filtered Source')
 - [rasgo_pivot](https://docs.rasgoml.com/rasgo-docs/pyrasgo/user-defined-transforms-udts/table-transforms/rasgo_pivot)
 - [rasgo_unpivot](https://docs.rasgoml.com/rasgo-docs/pyrasgo/user-defined-transforms-udts/table-transforms/rasgo_unpivot)
 - [rasgo_group_by](https://docs.rasgoml.com/rasgo-docs/pyrasgo/user-defined-transforms-udts/table-transforms/rasgo_group-by)
+- [rasgo_join](https://docs.rasgoml.com/rasgo-docs/pyrasgo/user-defined-transforms-udts/table-transforms/rasgo_join)
 - [rasgo_union](https://docs.rasgoml.com/rasgo-docs/pyrasgo/user-defined-transforms-udts/table-transforms/rasgo_union)
 
 ## Row Transforms

--- a/docs/table_transforms/rasgo_join.md
+++ b/docs/table_transforms/rasgo_join.md
@@ -1,0 +1,33 @@
+
+
+# rasgo_join
+
+Join a source table with another join table based on certain join keys between table. **NOTE**: If columns in the Join table are the same from the source table, the outputted column name from the join table will prefixxed with its table name. 
+
+## Parameters
+
+|    Argument    |    Type     |                                           Description                                            |
+| -------------- | ----------- | ------------------------------------------------------------------------------------------------ |
+| join_table_id  | source      | Source id of the table to join with the source one.                                              |
+| join_type      | string      | 'LEFT','RIGHT', 'INNER', or None                                                                 |
+| source_columns | column_list | Column/s to join from the source table. Col index in list must match with `joined_colums` param. |
+| joined_colums  | column_list | Column/s to join from the join table. Col index in list must match with `source_columns` param.  |
+
+
+## Example
+
+```python
+# Perform a RIGHT join, joining on keys 'MONTH'/'MONTH_NUM', 'FIPS/ZIP_CODE', and 'COVID_DEATHS'
+source.transform(
+  transform_name='rasgo_join',
+  join_table_id=363,
+  join_type='RIGHT',
+  source_columns=['MONTH', 'FIPS', 'COVID_DEATHS'],
+  joined_colums=['MONTH_NUM', 'ZIP_CODE', 'COVID_DEATHS']
+).preview()
+```
+
+## Source Code
+
+{% embed url="https://github.com/rasgointelligence/RasgoUDTs/blob/main/table_transforms/rasgo_join/rasgo_join.sql" %}
+

--- a/table_transforms/rasgo_join/rasgo_join.sql
+++ b/table_transforms/rasgo_join/rasgo_join.sql
@@ -1,0 +1,7 @@
+SELECT t1.*, t2.* 
+FROM {{ source_table }} as t1
+LEFT JOIN {{ rasgo_source_ref(join_table_id) }} as t2
+ON 
+{%- for s_col in source_columns -%}
+    {{ ' AND' if not loop.first else ''}} t1.{{ s_col }} = t2.{{ joined_colums[loop.index0] }}
+{%- endfor -%}

--- a/table_transforms/rasgo_join/rasgo_join.sql
+++ b/table_transforms/rasgo_join/rasgo_join.sql
@@ -1,7 +1,54 @@
-SELECT t1.*, t2.* 
+{#
+Jinja Macro to generate a query that would get all 
+the columns in a table by source_Id or fqtn
+#}
+{%- macro get_source_col_names(source_id=None, source_table_fqtn=None) -%}
+    {%- set database, schema, table = '', '', '' -%}
+    {%- if source_table_fqtn -%}
+        {%- set database, schema, table = source_table_fqtn.split('.') -%}
+    {%- else -%}
+        {%- set database, schema, table = rasgo_source_ref(source_id).split('.') -%}
+    {%- endif -%}
+        SELECT COLUMN_NAME FROM {{ database }}.information_schema.columns
+        WHERE TABLE_CATALOG = '{{ database }}'
+        AND   TABLE_SCHEMA = '{{ schema }}'
+        AND   TABLE_NAME = '{{ table }}'
+{%- endmacro -%}
+
+{# Jinja Macro to get the table name from source_id #}
+{%- macro get_table_name(source_id) -%}
+    {%- set database, schema, table = rasgo_source_ref(source_id).split('.') -%}
+    {{ table }}
+{%- endmacro -%}
+
+
+{# Get all Columns in Source Table #}
+{%- set col_names_source_df = run_query(get_source_col_names(source_table_fqtn=source_table)) -%}
+{%- set source_col_names = col_names_source_df['COLUMN_NAME'].to_list() -%}
+
+{# Get all Columns and Table Name in Join Table #}
+{%- set col_names_join_df = run_query(get_source_col_names(source_id=join_table_id)) -%}
+{%- set join_col_names = col_names_join_df['COLUMN_NAME'].to_list() -%}
+{%- set join_table_name = get_table_name(join_table_id) -%}
+
+
+
+SELECT
+{%- for source_col in source_col_names %}
+  t1.{{ source_col }},
+{%- endfor -%}
+
+
+{%- for join_col in join_col_names -%}
+    {# If join column name is in source table, prepend it with join table name #}
+    {%- set join_col_name =  join_col -%}
+    {%- if join_col in source_col_names -%}
+        {%- set join_col_name =  join_table_name + '_' + join_col -%}
+    {%- endif %}
+  t2.{{ join_col }} as {{ join_col_name }}{{ ',' if not loop.last else '' }}
+{%- endfor %}
 FROM {{ source_table }} as t1
-LEFT JOIN {{ rasgo_source_ref(join_table_id) }} as t2
-ON 
-{%- for s_col in source_columns -%}
-    {{ ' AND' if not loop.first else ''}} t1.{{ s_col }} = t2.{{ joined_colums[loop.index0] }}
+{{ join_type + ' ' if join_type else '' | upper }}JOIN {{ rasgo_source_ref(join_table_id) }} as t2
+{%- for s_col in source_columns %}
+{{ ' AND' if not loop.first else 'ON'}} t1.{{ s_col }} = t2.{{ joined_colums[loop.index0] }}
 {%- endfor -%}

--- a/table_transforms/rasgo_join/rasgo_join.yaml
+++ b/table_transforms/rasgo_join/rasgo_join.yaml
@@ -21,6 +21,6 @@ example_code: |
     transform_name='rasgo_join',
     join_table_id=363,
     join_type='RIGHT',
-    source_columns=['MONTH_NUM', 'FIPS', 'COVID_DEATHS'],
+    source_columns=['MONTH', 'FIPS', 'COVID_DEATHS'],
     joined_colums=['MONTH_NUM', 'ZIP_CODE', 'COVID_DEATHS']
   ).preview()

--- a/table_transforms/rasgo_join/rasgo_join.yaml
+++ b/table_transforms/rasgo_join/rasgo_join.yaml
@@ -1,0 +1,26 @@
+name: rasgo_join
+transform_type: table
+source_code: rasgo_join.sql
+description:  "Join a source table with another join table based on certain join keys between table. **NOTE**: If columns in the Join table are the same from the source table, the outputted column name from the join table will prefixxed with its table name. "
+arguments:
+  join_table_id:
+    type: source
+    description: Source id of the table to join with the source one.
+  join_type:
+    type: string
+    description: "'LEFT','RIGHT', 'INNER', or None"
+  source_columns:
+    type: column_list
+    description: Column/s to join from the source table. Col index in list must match with `joined_colums` param.
+  joined_colums:
+    type: column_list
+    description:  Column/s to join from the join table. Col index in list must match with `source_columns` param.
+example_code: |
+  # Perform a RIGHT join, joining on keys 'MONTH'/'MONTH_NUM', 'FIPS/ZIP_CODE', and 'COVID_DEATHS'
+  source.transform(
+    transform_name='rasgo_join',
+    join_table_id=363,
+    join_type='RIGHT',
+    source_columns=['MONTH_NUM', 'FIPS', 'COVID_DEATHS'],
+    joined_colums=['MONTH_NUM', 'ZIP_CODE', 'COVID_DEATHS']
+  ).preview()


### PR DESCRIPTION
Perform a Join between a source and a join table on certain matching keys. If columns in the Join table are the same from the source table, the outputted column name from the join table will prefixxed with its table name. 

Code below outputs

```python
source.transform(
    transform_name=transform_name,
    join_table_id=363,
    join_type='RIGHT',
    source_columns=['MONTH', 'FIPS', 'COVID_DEATHS'],
    joined_colums=['MONTH_NUM', 'ZIP_CODE', 'COVID_DEATHS']
).preview_sql()
```

```sql
SELECT
  t1.DATE,
  t1.COVID_NEW_CASES,
  t1.COVID_DEATHS,
  t1.COVID_CUMULATIVE_CASES,
  t1.YEAR,
  t1.FIPS,
  t1.MONTH,
  t2.DATE as COVID_MONTHLY_FEATURES_DATE,
  t2.COVID_NEW_CASES as COVID_MONTHLY_FEATURES_COVID_NEW_CASES,
  t2.YEAR as COVID_MONTHLY_FEATURES_YEAR,
  t2.COVID_CUMULATIVE_CASES as COVID_MONTHLY_FEATURES_COVID_CUMULATIVE_CASES,
  t2.ZIP_CODE as ZIP_CODE,
  t2.MONTH_NUM as MONTH_NUM,
  t2.COVID_DEATHS as COVID_MONTHLY_FEATURES_COVID_DEATHS
FROM RASGOCOMMUNITY.PUBLIC.COVID_MONTHLY_FEATURES as t1
RIGHT JOIN RASGOCOMMUNITY.PUBLIC.COVID_MONTHLY_FEATURES as t2
ON t1.MONTH = t2.MONTH_NUM
 AND t1.FIPS = t2.ZIP_CODE
 AND t1.COVID_DEATHS = t2.COVID_DEATHS
```