### PR TITLE
create new_rename

### DIFF
--- a/column_transforms/datediff/datediff.yaml
+++ b/column_transforms/datediff/datediff.yaml
@@ -2,14 +2,14 @@ name: datediff
 description: Calculates the difference between two date, time, or timestamp expressions based on the date or time part requested. The function returns the result of subtracting the second argument from the third argument.
 arguments:
   date_part:
-    type: string
+    type: date_part
     description: |
        Must be one of the values listed in [Supported Date and Time Parts](https://docs.snowflake.com/en/sql-reference/functions-date-time.html#label-supported-date-time-parts)
   date_val_1:
-    type: string
+    type: mixed_value
     description: Date column to subtract from `date_val_2`. Can be a date column, date, time, or timestamp.
   date_val_2:
-    type: string
+    type: mixed_value
     description: Date column to be subtracted by `date_val_1`. Can be a date column, date, time, or timestamp.
 example_code: |
     source = rasgo.read.source_data(source.id)

--- a/column_transforms/if_then/if_then.yaml
+++ b/column_transforms/if_then/if_then.yaml
@@ -10,7 +10,7 @@ arguments:
     type: list
     description: A nested list. In each inner list the first element would be the condition to check, and the second the value with which to fill.
   default:
-    type: string | int | column
+    type: mixed_value
     description: The default value with which to fill the new column. Please enclose fixed strings in quotes inside of the argument (e.g., below)
   alias:
     type: string

--- a/column_transforms/new_rename/new_rename.sql
+++ b/column_transforms/new_rename/new_rename.sql
@@ -1,0 +1,30 @@
+{#
+Jinja Macro to generate a query that would get all 
+the columns in a table by source_Id or fqtn
+#}
+{%- macro get_source_col_names(source_id=None, source_table_fqtn=None) -%}
+    {%- set database, schema, table = '', '', '' -%}
+    {%- if source_table_fqtn -%}
+        {%- set database, schema, table = source_table_fqtn.split('.') -%}
+    {%- else -%}
+        {%- set database, schema, table = rasgo_source_ref(source_id).split('.') -%}
+    {%- endif -%}
+        SELECT COLUMN_NAME FROM {{ database }}.information_schema.columns
+        WHERE TABLE_CATALOG = '{{ database }}'
+        AND   TABLE_SCHEMA = '{{ schema }}'
+        AND   TABLE_NAME = '{{ table }}'
+{%- endmacro -%}
+
+
+{# Get all Columns in Source Table #}
+{%- set col_names_source_df = run_query(get_source_col_names(source_table_fqtn=source_table)) -%}
+{%- set source_col_names = col_names_source_df['COLUMN_NAME'].to_list() -%}
+
+SELECT
+{%- for target_col, new_name in renames.items() %}
+    {{target_col}} AS {{new_name}}{{ ", " if not loop.last else "" }}
+{%- endfor -%}
+{%- for col in source_col_names %}
+    {%- if col not in renames %}, {{col}}{%- endif -%}
+{% endfor %}
+FROM {{ source_table }}

--- a/column_transforms/new_rename/new_rename.yaml
+++ b/column_transforms/new_rename/new_rename.yaml
@@ -1,0 +1,20 @@
+name: rename
+description: |
+  Rename columns by passing a renames dict.
+
+arguments:
+  renames:
+    type: column_value_dict
+    description: A dict representing each existing column to be renamed and its corresponding new name.
+example_code: |
+    source = rasgo.read.source_data(source_id)
+    
+    t1 = source.transform(
+        transform_name='rename',
+        imputations={
+          'DS_WEATHER_ICON': 'Weather',
+          'DS_DAILY_HIGH_TEMP': 'High_Temp',
+          'DS_DAILY_LOW_TEMP': 'Low_Temp'
+  })
+
+    t1.preview()

--- a/column_transforms/new_rename/new_rename.yaml
+++ b/column_transforms/new_rename/new_rename.yaml
@@ -7,14 +7,14 @@ arguments:
     type: column_value_dict
     description: A dict representing each existing column to be renamed and its corresponding new name.
 example_code: |
-    source = rasgo.read.source_data(source_id)
-    
-    t1 = source.transform(
-        transform_name='rename',
-        imputations={
-          'DS_WEATHER_ICON': 'Weather',
-          'DS_DAILY_HIGH_TEMP': 'High_Temp',
-          'DS_DAILY_LOW_TEMP': 'Low_Temp'
+  source = rasgo.read.source_data(source_id)
+
+  t1 = source.transform(
+      transform_name='rename',
+      renames={
+        'DS_WEATHER_ICON': 'Weather',
+        'DS_DAILY_HIGH_TEMP': 'High_Temp',
+        'DS_DAILY_LOW_TEMP': 'Low_Temp'
   })
 
-    t1.preview()
+  t1.preview()

--- a/docs/column_transforms/datediff.md
+++ b/docs/column_transforms/datediff.md
@@ -6,11 +6,11 @@ Calculates the difference between two date, time, or timestamp expressions based
 
 ## Parameters
 
-|  Argument  |  Type  |                                                                                Description                                                                                 |
-| ---------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| date_part  | string | Must be one of the values listed in [Supported Date and Time Parts](https://docs.snowflake.com/en/sql-reference/functions-date-time.html#label-supported-date-time-parts)  |
-| date_val_1 | string | Date column to subtract from `date_val_2`. Can be a date column, date, time, or timestamp.                                                                                 |
-| date_val_2 | string | Date column to be subtracted by `date_val_1`. Can be a date column, date, time, or timestamp.                                                                              |
+|  Argument  |    Type     |                                                                                Description                                                                                 |
+| ---------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| date_part  | date_part   | Must be one of the values listed in [Supported Date and Time Parts](https://docs.snowflake.com/en/sql-reference/functions-date-time.html#label-supported-date-time-parts)  |
+| date_val_1 | mixed_value | Date column to subtract from `date_val_2`. Can be a date column, date, time, or timestamp.                                                                                 |
+| date_val_2 | mixed_value | Date column to be subtracted by `date_val_1`. Can be a date column, date, time, or timestamp.                                                                              |
 
 
 ## Example

--- a/docs/column_transforms/if_then.md
+++ b/docs/column_transforms/if_then.md
@@ -11,11 +11,11 @@ A default value for the new column should be set, as should the output column na
 
 ## Parameters
 
-|  Argument  |         Type          |                                                            Description                                                            |
-| ---------- | --------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| conditions | list                  | A nested list. In each inner list the first element would be the condition to check, and the second the value with which to fill. |
-| default    | string \| int \| column | The default value with which to fill the new column. Please enclose fixed strings in quotes inside of the argument (e.g., below)  |
-| alias      | string                | The name of the output column in the new dataset.                                                                                 |
+|  Argument  |    Type     |                                                            Description                                                            |
+| ---------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| conditions | list        | A nested list. In each inner list the first element would be the condition to check, and the second the value with which to fill. |
+| default    | mixed_value | The default value with which to fill the new column. Please enclose fixed strings in quotes inside of the argument (e.g., below)  |
+| alias      | string      | The name of the output column in the new dataset.                                                                                 |
 
 
 ## Example

--- a/docs/column_transforms/new_rename.md
+++ b/docs/column_transforms/new_rename.md
@@ -1,0 +1,35 @@
+
+
+# rename
+
+Rename columns by passing a renames dict.
+
+
+## Parameters
+
+| Argument |       Type        |                                      Description                                       |
+| -------- | ----------------- | -------------------------------------------------------------------------------------- |
+| renames  | column_value_dict | A dict representing each existing column to be renamed and its corresponding new name. |
+
+
+## Example
+
+```python
+source = rasgo.read.source_data(source_id)
+
+t1 = source.transform(
+    transform_name='rename',
+    renames={
+      'DS_WEATHER_ICON': 'Weather',
+      'DS_DAILY_HIGH_TEMP': 'High_Temp',
+      'DS_DAILY_LOW_TEMP': 'Low_Temp'
+})
+
+t1.preview()
+
+```
+
+## Source Code
+
+{% embed url="https://github.com/rasgointelligence/RasgoUDTs/blob/main/column_transforms/new_rename/new_rename.sql" %}
+


### PR DESCRIPTION
would like to sunset rename and move to this new_rename. will follow a similar paradigm on some other transforms. reasons:
- simpler args (only one)
- dont have the weirdness of checking if two lists are the same length
- working with @phillip-rasgo  to implement a nice UI input for this arg type `column_value_dict` which will apply to a surprising number of transforms