### PR TITLE
funky little change, maybe not worth

### DIFF
--- a/column_transforms/drop_columns/drop_columns.sql
+++ b/column_transforms/drop_columns/drop_columns.sql
@@ -10,9 +10,9 @@ the columns in a table by source_Id or fqtn
         {%- set database, schema, table = rasgo_source_ref(source_id).split('.') -%}
     {%- endif -%}
         SELECT COLUMN_NAME FROM {{ database }}.information_schema.columns
-        WHERE TABLE_CATALOG = '{{ database }}'
-        AND   TABLE_SCHEMA = '{{ schema }}'
-        AND   TABLE_NAME = '{{ table }}'
+        WHERE TABLE_CATALOG = '{{ database|upper }}'
+        AND   TABLE_SCHEMA = '{{ schema|upper }}'
+        AND   TABLE_NAME = '{{ table|upper }}'
 {%- endmacro -%}
 
 {% if include_cols and exclude_cols is defined %}

--- a/column_transforms/impute/impute.sql
+++ b/column_transforms/impute/impute.sql
@@ -6,9 +6,9 @@ the columns in a table by fqtn
     {%- set database, schema, table = '', '', '' -%}
     {%- set database, schema, table = source_table_fqtn.split('.') -%}
     SELECT COLUMN_NAME FROM {{ database }}.information_schema.columns
-    WHERE TABLE_CATALOG = '{{ database }}'
-    AND   TABLE_SCHEMA = '{{ schema }}'
-    AND   TABLE_NAME = '{{ table }}'
+    WHERE TABLE_CATALOG = '{{ database|upper }}'
+    AND   TABLE_SCHEMA = '{{ schema|upper }}'
+    AND   TABLE_NAME = '{{ table|upper }}'
 {%- endmacro -%}
 
 {# 

--- a/column_transforms/new_rename/new_rename.sql
+++ b/column_transforms/new_rename/new_rename.sql
@@ -10,9 +10,9 @@ the columns in a table by source_Id or fqtn
         {%- set database, schema, table = rasgo_source_ref(source_id).split('.') -%}
     {%- endif -%}
         SELECT COLUMN_NAME FROM {{ database }}.information_schema.columns
-        WHERE TABLE_CATALOG = '{{ database }}'
-        AND   TABLE_SCHEMA = '{{ schema }}'
-        AND   TABLE_NAME = '{{ table }}'
+        WHERE TABLE_CATALOG = '{{ database|upper }}'
+        AND   TABLE_SCHEMA = '{{ schema|upper }}'
+        AND   TABLE_NAME = '{{ table|upper }}'
 {%- endmacro -%}
 
 

--- a/column_transforms/one_hot_encode/one_hot_encode.sql
+++ b/column_transforms/one_hot_encode/one_hot_encode.sql
@@ -6,9 +6,9 @@ the columns in a table by fqtn
     {%- set database, schema, table = '', '', '' -%}
     {%- set database, schema, table = source_table_fqtn.split('.') -%}
     SELECT COLUMN_NAME FROM {{ database }}.information_schema.columns
-    WHERE TABLE_CATALOG = '{{ database }}'
-    AND   TABLE_SCHEMA = '{{ schema }}'
-    AND   TABLE_NAME = '{{ table }}'
+    WHERE TABLE_CATALOG = '{{ database|upper }}'
+    AND   TABLE_SCHEMA = '{{ schema|upper }}'
+    AND   TABLE_NAME = '{{ table|upper }}'
 {%- endmacro -%}
 
 {# Marcro to make queries for one hot encode columns #}

--- a/column_transforms/rename/rename.sql
+++ b/column_transforms/rename/rename.sql
@@ -10,9 +10,9 @@ the columns in a table by source_Id or fqtn
         {%- set database, schema, table = rasgo_source_ref(source_id).split('.') -%}
     {%- endif -%}
         SELECT COLUMN_NAME FROM {{ database }}.information_schema.columns
-        WHERE TABLE_CATALOG = '{{ database }}'
-        AND   TABLE_SCHEMA = '{{ schema }}'
-        AND   TABLE_NAME = '{{ table }}'
+        WHERE TABLE_CATALOG = '{{ database|upper }}'
+        AND   TABLE_SCHEMA = '{{ schema|upper }}'
+        AND   TABLE_NAME = '{{ table|upper }}'
 {%- endmacro -%}
 
 

--- a/table_transforms/join/join.sql
+++ b/table_transforms/join/join.sql
@@ -10,8 +10,8 @@ the columns in a table by source_Id or fqtn
         {%- set database, schema, table = rasgo_source_ref(source_id).split('.') -%}
     {%- endif -%}
         SELECT COLUMN_NAME FROM {{ database }}.information_schema.columns
-        WHERE TABLE_CATALOG = '{{ database }}'
-        AND   TABLE_SCHEMA = '{{ schema }}'
+        WHERE TABLE_CATALOG = '{{ database|upper }}'
+        AND   TABLE_SCHEMA = '{{ schema|upper }}'
         AND   TABLE_NAME = '{{ table|upper }}'
 {%- endmacro -%}
 

--- a/table_transforms/join/join.sql
+++ b/table_transforms/join/join.sql
@@ -12,7 +12,7 @@ the columns in a table by source_Id or fqtn
         SELECT COLUMN_NAME FROM {{ database }}.information_schema.columns
         WHERE TABLE_CATALOG = '{{ database }}'
         AND   TABLE_SCHEMA = '{{ schema }}'
-        AND   TABLE_NAME = '{{ table }}'
+        AND   TABLE_NAME = '{{ table|upper }}'
 {%- endmacro -%}
 
 {# Jinja Macro to get the table name from source_id #}

--- a/table_transforms/union/union.sql
+++ b/table_transforms/union/union.sql
@@ -10,9 +10,9 @@ the columns in a table by source_Id or fqtn
         {%- set database, schema, table = rasgo_source_ref(source_id).split('.') -%}
     {%- endif -%}
         SELECT COLUMN_NAME FROM {{ database }}.information_schema.columns
-        WHERE TABLE_CATALOG = '{{ database }}'
-        AND   TABLE_SCHEMA = '{{ schema }}'
-        AND   TABLE_NAME = '{{ table }}'
+        WHERE TABLE_CATALOG = '{{ database|upper }}'
+        AND   TABLE_SCHEMA = '{{ schema|upper }}'
+        AND   TABLE_NAME = '{{ table|upper }}'
 {%- endmacro -%}
 
 {# Get all Columns in Source Table #}


### PR DESCRIPTION
TIL that capitalization matters on the select from information schema. I have a source with a name like `RASGO.PUBLIC.SZ_this_TABLE_name`, but the table in Snowflake was created as `RASGO.PUBLIC.SZ_THIS_TABLE_NAME`. The macro `get_source_col_names` is case sensitive. What do y'all think about this change? It worked for my use case, but not sure if it would break anything else.