### PR TITLE
start a discussion

### DIFF
--- a/column_transforms/datepart/datepart.sql
+++ b/column_transforms/datepart/datepart.sql
@@ -1,4 +1,3 @@
 SELECT *,
-// TODO: at odds w docs
 {% for col in date_columns %}DATE_PART('{{date_part}}', {{col}}) as {{col}}_datepart_{{date_part}} {{ ", " if not loop.last else "" }}{% endfor %}
 from {{ source_table }}

--- a/column_transforms/datepart/datepart.sql
+++ b/column_transforms/datepart/datepart.sql
@@ -1,3 +1,4 @@
 SELECT *,
+// TODO: at odds w docs
 {% for col in date_columns %}DATE_PART('{{date_part}}', {{col}}) as {{col}}_datepart_{{date_part}} {{ ", " if not loop.last else "" }}{% endfor %}
 from {{ source_table }}

--- a/column_transforms/datepart/datepart.yaml
+++ b/column_transforms/datepart/datepart.yaml
@@ -8,13 +8,12 @@ arguments:
     type: date_part
     description: the desired grain of the date; an exhaustive list of valid date parts can be [found here](https://docs.snowflake.com/en/sql-reference/functions-date-time.html#label-supported-date-time-parts).
 example_code: |
-    source = rasgo.read.source_data(source.id)
+    source = rasgo.get.dataset(dataset.id)
     
     t1 = source.transform(
       transform_name='datepart',
-      # TODO: at odds w code
-      date_parts = ['month'],
-      date_column = 'DATE'
+      date_part = 'month',
+      date_columns = ['DATE', "OTHER_DATE_COL"]
     )
     
     t1.preview()

--- a/column_transforms/datepart/datepart.yaml
+++ b/column_transforms/datepart/datepart.yaml
@@ -12,6 +12,7 @@ example_code: |
     
     t1 = source.transform(
       transform_name='datepart',
+      # TODO: at odds w code
       date_parts = ['month'],
       date_column = 'DATE'
     )

--- a/docs/column_transforms/datepart.md
+++ b/docs/column_transforms/datepart.md
@@ -15,13 +15,12 @@ Extracts a specific part of a date column. For example, if the input is '2021-01
 ## Example
 
 ```python
-source = rasgo.read.source_data(source.id)
+source = rasgo.get.dataset(dataset.id)
 
 t1 = source.transform(
   transform_name='datepart',
-  # TODO: at odds w code
-  date_parts = ['month'],
-  date_column = 'DATE'
+  date_part = 'month',
+  date_columns = ['DATE', "OTHER_DATE_COL"]
 )
 
 t1.preview()

--- a/docs/column_transforms/datepart.md
+++ b/docs/column_transforms/datepart.md
@@ -19,6 +19,7 @@ source = rasgo.read.source_data(source.id)
 
 t1 = source.transform(
   transform_name='datepart',
+  # TODO: at odds w code
   date_parts = ['month'],
   date_column = 'DATE'
 )


### PR DESCRIPTION
The `datepart` code expects one date_part type, but multiple columns to apply the part to; the docs expect multiple datepart types, but only one column to which to apply them. How do we actually want to order these? 1:many? many:1? Many:many?